### PR TITLE
Fix for Database Create command

### DIFF
--- a/internal/Database/Create.go
+++ b/internal/Database/Create.go
@@ -8,16 +8,6 @@ import (
 )
 
 func Create(filePath string) {
-	_, fileStatError := os.Stat(filePath)
-	if fileStatError != nil {
-		if os.IsExist(fileStatError) {
-			log.Fatal(fileStatError)
-		}
-		fileDeleteError := os.Remove(filePath)
-		if fileDeleteError != nil {
-			log.Fatal(fileDeleteError)
-		}
-	}
 	file, creationError := os.Create(filePath)
 	if creationError != nil {
 		log.Fatal(creationError)


### PR DESCRIPTION
This is a fix for the `database create` command, now the command will successfully create a new file if it doesn't exists